### PR TITLE
Fixed a bug that class comments without indentation collapsed

### DIFF
--- a/src/DotnetDocument/Syntax/DocumentationBuilder.cs
+++ b/src/DotnetDocument/Syntax/DocumentationBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using DotnetDocument.Utils;
@@ -235,9 +234,12 @@ namespace DotnetDocument.Syntax
             var indentationTrivia = SyntaxUtils
                 .GetIndentationTrivia(node);
 
+            // Get the new line string
+            var newLine = SyntaxUtils.GetNewLine(leadingTrivia);
+
             // Declare a new line element using the method indentation
             var xmlNewLine = DocumentationFactory
-                .XmlNewLineToken(indentationTrivia);
+                .XmlNewLineToken(indentationTrivia, newLine);
 
             // Declare a new line node 
             var newLineXmlNode = SyntaxFactory
@@ -283,7 +285,7 @@ namespace DotnetDocument.Syntax
             var documentationTrivia = SyntaxFactory.Trivia(docCommentTriviaSyntax);
 
             // TODO: Research this
-            var endOfLineTrivia = SyntaxFactory.EndOfLine(Environment.NewLine);
+            var endOfLineTrivia = SyntaxFactory.EndOfLine(newLine);
 
             var newLeadingTrivia = leadingTrivia
                 .Add(documentationTrivia)

--- a/src/DotnetDocument/Syntax/DocumentationFactory.cs
+++ b/src/DotnetDocument/Syntax/DocumentationFactory.cs
@@ -17,9 +17,10 @@ namespace DotnetDocument.Syntax
         /// Xmls the new line token using the specified indentation trivia
         /// </summary>
         /// <param name="indentationTrivia">The indentation trivia</param>
+        /// <param name="newLine">The new line string</param>
         /// <returns>The syntax token</returns>
-        public static SyntaxToken XmlNewLineToken(SyntaxTrivia indentationTrivia) => SyntaxFactory
-            .XmlTextNewLine(Environment.NewLine, false)
+        public static SyntaxToken XmlNewLineToken(SyntaxTrivia indentationTrivia, string newLine) => SyntaxFactory
+            .XmlTextNewLine(newLine, false)
             .WithTrailingTrivia(SyntaxFactory.TriviaList(indentationTrivia, SyntaxFactory
                 .DocumentationCommentExterior("/// ")));
 

--- a/src/DotnetDocument/Syntax/SyntaxUtils.cs
+++ b/src/DotnetDocument/Syntax/SyntaxUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -26,6 +27,11 @@ namespace DotnetDocument.Syntax
             {
                 var indentationTrivia = leadingTrivia
                     .Last();
+                var indentationTriviaString = indentationTrivia.ToFullString();
+                if (indentationTriviaString is "\r" or "\n" or "\r\n")
+                {
+                    return SyntaxFactory.ElasticMarker;
+                }
 
                 return indentationTrivia;
             }
@@ -300,6 +306,21 @@ namespace DotnetDocument.Syntax
                 .DescendantNodesAndSelf()
                 .OfType<TSyntaxNode>()
                 .First();
+        }
+
+        /// <summary>
+        /// Get the new line string
+        /// </summary>
+        /// <param name="triviaList"></param>
+        /// <returns>The new line string</returns>
+        public static string GetNewLine(SyntaxTriviaList triviaList)
+        {
+            var fullString = triviaList.ToFullString();
+            if (Regex.IsMatch(fullString, "\r\n")) return "\r\n";
+            if (Regex.IsMatch(fullString, "\r")) return "\r";
+            if (Regex.IsMatch(fullString, "\n")) return "\n";
+
+            return Environment.NewLine;
         }
     }
 }

--- a/src/DotnetDocument/Syntax/SyntaxUtils.cs
+++ b/src/DotnetDocument/Syntax/SyntaxUtils.cs
@@ -22,6 +22,10 @@ namespace DotnetDocument.Syntax
         {
             var leadingTrivia = node
                 .GetLeadingTrivia();
+            if (leadingTrivia.Count == 0)
+            {
+                return SyntaxFactory.ElasticMarker;
+            }
 
             try
             {

--- a/test/DotnetDocument.Tests/Strategies/ClassDocumentationStrategyTests.cs
+++ b/test/DotnetDocument.Tests/Strategies/ClassDocumentationStrategyTests.cs
@@ -23,6 +23,7 @@ namespace DotnetDocument.Tests.Strategies
         /// <param name="expectedCommentedCode">The expected commented code</param>
         [Theory(DisplayName = "Should document")]
         [InlineData(TestCode.WithoutDoc.SimpleClass, TestCode.WithDoc.SimpleClass)]
+        [InlineData(TestCode.WithoutDoc.SimpleClassWithoutIndent, TestCode.WithDoc.SimpleClassWithoutIndent)]
         [InlineData(TestCode.WithoutDoc.ClassWithInheritance, TestCode.WithDoc.ClassWithInheritance)]
         public void ShouldDocument(string uncommentedCode, string expectedCommentedCode)
         {

--- a/test/DotnetDocument.Tests/Strategies/TestCode.cs
+++ b/test/DotnetDocument.Tests/Strategies/TestCode.cs
@@ -23,6 +23,18 @@ namespace DotnetDocument.Tests.Strategies
     }";
 
             /// <summary>
+            /// The simple without indent
+            /// </summary>
+            public const string SimpleClassWithoutIndent = @"
+public class UserRepository
+{
+    public User Get(string id)
+    {
+        return new User();
+    }
+}";
+
+            /// <summary>
             /// The class with inheritance
             /// </summary>
             public const string ClassWithInheritance = @"
@@ -99,6 +111,21 @@ public class UserService
             return new User();
         }
     }";
+
+            /// <summary>
+            /// The simple without indent
+            /// </summary>
+            public const string SimpleClassWithoutIndent = @"
+/// <summary>
+/// The user repository class
+/// </summary>
+public class UserRepository
+{
+    public User Get(string id)
+    {
+        return new User();
+    }
+}";
 
             /// <summary>
             /// The class with inheritance


### PR DESCRIPTION
<img width="300" alt="スクリーンショット 2023-03-21 162604" src="https://user-images.githubusercontent.com/5210329/226542043-d2ca8b87-76ae-499d-8734-1a122cc89b2e.png">
<img width="300" alt="スクリーンショット 2023-03-21 162637" src="https://user-images.githubusercontent.com/5210329/226542054-7f32b8cb-e46d-444f-b280-85c352f4baf9.png">
