### PR TITLE
Fix SubstringBetween length calculation

### DIFF
--- a/src/DotnetDocument/Extensions/StringExtensions.cs
+++ b/src/DotnetDocument/Extensions/StringExtensions.cs
@@ -27,7 +27,8 @@ namespace DotnetDocument.Extensions
             var endIndex = text.IndexOf(end, StringComparison.Ordinal);
 
             if (text.Contains(start) && text.Contains(end) && startIndex < endIndex)
-                return text.Substring(startIndex + start.Length, endIndex - end.Length - startIndex);
+                return text.Substring(startIndex + start.Length,
+                    endIndex - startIndex - start.Length);
 
             return string.Empty;
         }

--- a/test/DotnetDocument.Tests/StringExtensionsTests.cs
+++ b/test/DotnetDocument.Tests/StringExtensionsTests.cs
@@ -27,5 +27,17 @@ namespace DotnetDocument.Tests
             substring.ShouldBe(expected);
         }
 
+        [Fact]
+        public void ShouldSubstringWithDifferentTokenLengths()
+        {
+            const string text = "This is <!--some comment--> in text.";
+
+            // Act
+            var substring = text.SubstringBetween("<!--", "-->");
+
+            // Assert
+            substring.ShouldBe("some comment");
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- fix substring length calculation in StringExtensions.SubstringBetween
- test SubstringBetween with different start/end token lengths

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841604eaf58832b874f97afd730add9